### PR TITLE
Fix: Verhindere Admin-Aussperrung im Impersonate-Modus bei aktivem Wa…

### DIFF
--- a/lib/Upkeep.php
+++ b/lib/Upkeep.php
@@ -225,6 +225,12 @@ public static function checkFrontend(): void
             return;
         }
 
+        // Im Impersonate-Modus: Prüfen, ob der ursprüngliche Benutzer (Impersonator) ein Admin ist
+        $impersonator = rex::getImpersonator();
+        if ($impersonator instanceof rex_user && $impersonator->isAdmin()) {
+            return;
+        }
+
         // Backend-Benutzer sperren
         $fragment = new rex_fragment();
         


### PR DESCRIPTION
…rtungsmodus

- Füge Prüfung für Impersonator-Berechtigung in checkBackend() hinzu
- Admins können sich jetzt nicht mehr selbst aussperren, wenn sie im Wartungsmodus die Identität eines anderen Benutzers annehmen
- Löst GitHub Issue #49: Admin wird aus Backend ausgesperrt

Die Änderung erweitert die checkBackend()-Methode um eine zusätzliche Prüfung: Wenn sich ein Benutzer im Impersonate-Modus befindet, wird geprüft, ob der ursprüngliche Benutzer (Impersonator) ein Administrator ist. Falls ja, wird der Zugriff gewährt, auch wenn der aktuell 'verkörperte' Benutzer kein Administrator ist.